### PR TITLE
Grave accent turning into left single quote in verbatim

### DIFF
--- a/definition/root.tex
+++ b/definition/root.tex
@@ -19,7 +19,7 @@
 %%
 %% support for SuccML changes
 %%
-\usepackage[deletedmarkup=xout,authormarkup=none]{changes}
+\usepackage[deletedmarkup=xout,authormarkup=none,commandnameprefix=ifneeded]{changes}
 \newcommand{\fixcolor}{blue}  % corrections to definition
 \newcommand{\addcolor}{magenta}  % new SuccML features
 \newcommand{\delcolor}{gray}

--- a/definition/syncor.tex
+++ b/definition/syncor.tex
@@ -247,7 +247,7 @@ following {\sl symbols}\index{7.3}
 \vspace*{-6pt}
 \begin{center}
 %\verb(!  %  &  $  +  -  /  :  <  =  >  ?  (@\verb(  \  ~  `  ^  |  *(
-\verb(!  %  &  $  #  +  -  /  :  <  =  >  ?  @  \  ~  `  ^  |  *(
+\verb(!  %  &  $  #  +  -  /  :  <  =  >  ?  @  \  ~ ( \tt{\textasciigrave} \verb(  ^  |  *(
 \end{center}
 \vspace*{-6pt}
 In either case, however, reserved words are excluded.   This means that for


### PR DESCRIPTION
The first patch gets the build working on my system, let me know if you want me to split this apart.

If anyone has a better fix for the second, what I did to get it showing the right character is in fact quite ugly...
So i'd happily change that to almost anything else which worked.